### PR TITLE
Add search scope in_taxon_ids

### DIFF
--- a/core/app/models/spree/product/scopes.rb
+++ b/core/app/models/spree/product/scopes.rb
@@ -77,6 +77,11 @@ module Spree
       taxons.first ? prepare_taxon_conditions(taxons) : where(nil)
     end
 
+    add_search_scope :in_taxon_ids do |*ids|
+      taxons = Spree::Taxon.where(id: ids.flatten)
+      taxons.empty? ? where(nil) : prepare_taxon_conditions(taxons)
+    end
+
     # a scope that finds all products having property specified by name, object or id
     add_search_scope :with_property do |property|
       joins(:properties).where(property_conditions(property))

--- a/frontend/app/controllers/spree/products_controller.rb
+++ b/frontend/app/controllers/spree/products_controller.rb
@@ -13,6 +13,7 @@ module Spree
       @searcher = build_searcher(params.merge(include_images: true))
       @products = @searcher.retrieve_products
       @taxonomies = Spree::Taxonomy.includes(root: :children)
+      @taxons = Spree::Taxon.all
     end
 
     def show


### PR DESCRIPTION
Add search scope to specifically target Taxon ID's. This appears to be duplicating work that can already be achieved by the search scope `in_taxons` but it does not. The search scope `in_taxons` relies on the method `get_taxons`. This method splits based on parameter types, which won't work in the case when ID's are strings because it will instead try to find based on the Taxon's name.
